### PR TITLE
Instantiate airflow plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,29 @@
 ## Operators
 
 ### FacultyJobRunNowOperator
-This operator triggers a Faculty job run and waits for an end event for the job run (such as COMPLETED or ERROR).
-It accepts the following parameters:
+
+This operator triggers a Faculty job run and waits for an end event
+for the job run (such as COMPLETED or ERROR).
+
+Use this operator in your DAG as follows:
+
+```py
+from airflow import DAG
+
+from airflow.operators.faculty import FacultyJobRunNowOperator
+
+dag = DAG("faculty_job_tutorial")
+
+run_job = FacultyJobRunNowOperator(
+    job_id="260938d9-1ed8-47eb-aaf2-a0f9d8830e3a",
+    project_id="e88728f6-c197-4f01-bdf2-df3fc92bfe4d",
+    polling_period_seconds=10,
+    task_id="trigger_job",
+    dag=dag
+)
+```
+
+The operator accepts the following parameters:
 
 ```
     :param job_id                       The Faculty job id

--- a/operators/faculty_operators.py
+++ b/operators/faculty_operators.py
@@ -3,9 +3,11 @@ import time
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
+from airflow.plugins_manager import AirflowPlugin
 
 import faculty
 from faculty.clients.job import RunState
+
 
 COMPLETED_RUN_STATES = {
     RunState.COMPLETED,
@@ -104,3 +106,8 @@ class FacultyJobRunNowOperator(BaseOperator):
         """
         # TODO: Use the Faculty job client to cancel the run.
         raise NotImplementedError
+
+
+class FacultyPlugin(AirflowPlugin):
+    name = "faculty"
+    operators = [FacultyJobRunNowOperator]


### PR DESCRIPTION
As far as I understand, prior to this PR, this plugin worked by just dropping the operator in a place that was on the PYTHONPATH of the dag code. To be honest, it's hard to tell since the installation instructions are lacking.

As far as I understand airflow, the [expected way to create plugins](https://airflow.apache.org/plugins.html) is to drop a Python file with a class that inherits from `AirflowPlugin` in the `$AIRFLOW_HOME/plugins` directory or, for greater portability, to create an entry point.