### PR TITLE
Vendor faculty library

### DIFF
--- a/airflow_faculty_plugin/faculty/__init__.py
+++ b/airflow_faculty_plugin/faculty/__init__.py
@@ -1,0 +1,100 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from . import session as faculty_session
+from . import clients
+
+
+def client(
+    resource,
+    credentials_path=None,
+    profile_name=None,
+    domain=None,
+    protocol=None,
+    client_id=None,
+    client_secret=None,
+    access_token_cache=None,
+):
+    """Construct a client for a Faculty resource.
+
+    Parameters
+    ----------
+    resource : str
+        The resource to construct a client for.
+    credentials_path : str or pathlib.Path, optional
+        The path of a file to load Faculty credentials from.
+    profile_name : str, optional
+        The name of the profile to read from the credentials file. The default
+        is 'default'.
+    domain : str, optional
+        The domain to access Faculty services at. This is provided when you
+        generate credentials in the platform.
+    protocol : str, optional
+        Either 'http' or 'https' (the default).
+    client_id : str, optional
+        The Faculty client ID to user. This is provided when you generate
+        credentials in the platform.
+    client_secret : str, optional
+        The Faculty client secret to use. This is provided when you generate
+        credentials in the platform.
+    access_token_cache : faculty.session.accesstoken.AccessTokenMemoryCache or
+    faculty.session.accesstoken.AccessTokenMemoryCache, optional
+        Set the access token cache used. The default is an
+        AccessTokenMemoryCache.
+
+    Examples
+    --------
+    To construct a client loading default configuration and credentials (from
+    ~/.config/faculty/credentials or from environment variables), simply call
+    this function with the resource type as a string:
+
+    >>> faculty.client("account")
+    <faculty.clients.account.AccountClient object at 0x10d4b7fd0>
+
+    To load a different configuration file, or load a profile from the file
+    other than 'default', pass the `credentials_path` or `profile_name`
+    arguments respectively:
+
+    >>> faculty.client(
+    ...     "account",
+    ...     credentials_path="other/credentials",
+    ...     profile_name="custom",
+    ... )
+    <faculty.clients.account.AccountClient object at 0x10e447550>
+
+    To set any of the domain, protocol, client ID or client secret, pass their
+    respective arguments. These always take higher precendence than values read
+    from configuration files or environment variables:
+
+    >>> faculty.client(
+    ...     "account",
+    ...     domain="services.faculty.myorganisation.com",
+    ...     protocol="http",
+    ...     client_id="d047dad1-175b-4810-84b1-c0ff6bbcf456",
+    ...     client_secret="Vk4a1FgSKlTplkK0GkToAdRTdsoU4XHuwCMQ",
+    ... )
+    <faculty.clients.account.AccountClient object at 0x10e4472b0>
+    """
+    session = faculty_session.get_session(
+        credentials_path=credentials_path,
+        profile_name=profile_name,
+        domain=domain,
+        protocol=protocol,
+        client_id=client_id,
+        client_secret=client_secret,
+        access_token_cache=access_token_cache,
+    )
+    client_class = clients.for_resource(resource)
+    return client_class(session)

--- a/airflow_faculty_plugin/faculty/clients/__init__.py
+++ b/airflow_faculty_plugin/faculty/clients/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .job import JobClient
+
+
+CLIENT_FOR_RESOURCE = {
+    "job": JobClient,
+}
+
+
+def for_resource(resource):
+    try:
+        return CLIENT_FOR_RESOURCE[resource]
+    except KeyError:
+        raise ValueError(
+            "unsupported resource {}, choose one of {}".format(
+                resource, set(CLIENT_FOR_RESOURCE.keys())
+            )
+        )

--- a/airflow_faculty_plugin/faculty/clients/auth.py
+++ b/airflow_faculty_plugin/faculty/clients/auth.py
@@ -1,0 +1,61 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from requests.auth import AuthBase
+
+
+class FacultyAuth(AuthBase):
+    """Requests auth implementation for accessing Faculty services.
+
+    Parameters
+    ----------
+    session : faculty.session.Session
+        The Faculty session to authenticate with
+
+    To perform an authenticated request against a Faculty service, first
+    construct an instance of this class with a session:
+
+    >>> import faculty.session
+    >>> session = faculty.session.get_session()
+    >>> auth = FacultyAuth(session)
+
+    then pass it as the ``auth`` argument when making a request with
+    ``requests``:
+
+    >>> import requests
+    >>> requests.get(
+            'https://servicename.services.example.my.faculty.ai',
+            auth=auth
+        )
+
+    You can also set it as the ``auth`` attribute on a
+    :class:`requests.Session`, so that subsequent requests will be
+    authenticated automatically:
+
+    >>> import requests
+    >>> session = requests.Session()
+    >>> session.auth = auth
+    """
+
+    def __init__(self, session):
+        self.session = session
+
+    def __call__(self, request):
+        access_token = self.session.access_token()
+
+        header_content = "Bearer {}".format(access_token.token)
+        request.headers["Authorization"] = header_content
+
+        return request

--- a/airflow_faculty_plugin/faculty/clients/base.py
+++ b/airflow_faculty_plugin/faculty/clients/base.py
@@ -112,9 +112,7 @@ class BaseClient(object):
 
     def _request(self, method, endpoint, check_status=True, *args, **kwargs):
         url = self.session.service_url(self.SERVICE_NAME, endpoint)
-        print(url)
         response = self.http_session.request(method, url, *args, **kwargs)
-        print(response)
         if check_status:
             _check_status(response)
         return response

--- a/airflow_faculty_plugin/faculty/clients/base.py
+++ b/airflow_faculty_plugin/faculty/clients/base.py
@@ -1,0 +1,135 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+
+from .auth import FacultyAuth
+
+
+class HttpError(Exception):
+    def __init__(self, response, error=None, error_code=None):
+        self.response = response
+        self.error = error
+        self.error_code = error_code
+
+
+HTTPError = HttpError  # For backwards compatiblity
+
+
+class BadRequest(HttpError):
+    pass
+
+
+class Unauthorized(HttpError):
+    pass
+
+
+class Forbidden(HttpError):
+    pass
+
+
+class NotFound(HttpError):
+    pass
+
+
+class MethodNotAllowed(HttpError):
+    pass
+
+
+class Conflict(HttpError):
+    pass
+
+
+class InternalServerError(HttpError):
+    pass
+
+
+class BadGateway(HttpError):
+    pass
+
+
+class ServiceUnavailable(HttpError):
+    pass
+
+
+class GatewayTimeout(HttpError):
+    pass
+
+
+HTTP_ERRORS = {
+    400: BadRequest,
+    401: Unauthorized,
+    403: Forbidden,
+    404: NotFound,
+    405: MethodNotAllowed,
+    409: Conflict,
+    500: InternalServerError,
+    502: BadGateway,
+    503: ServiceUnavailable,
+    504: GatewayTimeout,
+}
+
+
+def _check_status(response):
+    if response.status_code >= 400:
+        cls = HTTP_ERRORS.get(response.status_code, HttpError)
+        try:
+            data = response.json()
+        except ValueError:
+            data = {}
+        raise cls(response, data.get("error"), data.get("errorCode"))
+
+
+class BaseClient(object):
+
+    SERVICE_NAME = None
+
+    def __init__(self, session):
+        if self.SERVICE_NAME is None:
+            raise RuntimeError(
+                "must set SERVICE_NAME in subclasses of BaseClient"
+            )
+        self.session = session
+        self._http_session_cache = None
+
+    @property
+    def http_session(self):
+        if self._http_session_cache is None:
+            self._http_session_cache = requests.Session()
+            self._http_session_cache.auth = FacultyAuth(self.session)
+        return self._http_session_cache
+
+    def _request(self, method, endpoint, check_status=True, *args, **kwargs):
+        url = self.session.service_url(self.SERVICE_NAME, endpoint)
+        print(url)
+        response = self.http_session.request(method, url, *args, **kwargs)
+        print(response)
+        if check_status:
+            _check_status(response)
+        return response
+
+    def _get_raw(self, endpoint, *args, **kwargs):
+        return self._request("GET", endpoint, *args, **kwargs)
+
+    def _post_raw(self, endpoint, *args, **kwargs):
+        return self._request("POST", endpoint, *args, **kwargs)
+
+    def _put_raw(self, endpoint, *args, **kwargs):
+        return self._request("PUT", endpoint, *args, **kwargs)
+
+    def _patch_raw(self, endpoint, *args, **kwargs):
+        return self._request("PATCH", endpoint, *args, **kwargs)
+
+    def _delete_raw(self, endpoint, *args, **kwargs):
+        return self._request("DELETE", endpoint, *args, **kwargs)

--- a/airflow_faculty_plugin/faculty/clients/job.py
+++ b/airflow_faculty_plugin/faculty/clients/job.py
@@ -73,8 +73,6 @@ class JobClient(BaseClient):
         uuid.UUID
             The ID of the created run.
         """
-        print("starting...!!")
-
         if parameter_value_sets is None:
             parameter_value_sets = [{}]
 
@@ -88,9 +86,7 @@ class JobClient(BaseClient):
                 for parameter_values in parameter_value_sets
             ]
         }
-        print(payload)
         response = self._post_raw(endpoint, json=payload)
-        print(response)
         return uuid.UUID(response.json()["runId"])
 
     def get_run_state(self, project_id, job_id, run_identifier):

--- a/airflow_faculty_plugin/faculty/clients/job.py
+++ b/airflow_faculty_plugin/faculty/clients/job.py
@@ -1,0 +1,115 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from enum import Enum
+
+from .base import BaseClient
+
+
+class RunState(Enum):
+    QUEUED = "queued"
+    STARTING = "starting"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    ERROR = "error"
+
+
+class JobClient(BaseClient):
+
+    SERVICE_NAME = "steve"
+
+    def create_run(self, project_id, job_id, parameter_value_sets=None):
+        """Create a run for a job.
+
+        When creating a run, each item in ``parameter_value_sets`` will be
+        translated into an individual subrun. For example, to start a single
+        run of job with ``file`` and ``alpha`` arguments:
+
+        >>> client.create_run(
+        >>>     project_id, job_id, [{"file": "data.txt", "alpha": "0.1"}]
+        >>> )
+
+        Pass additional entries in ``parameter_value_sets`` to start a run
+        array with multiple subruns. For example, for a job with a single
+        ``file`` argument:
+
+        >>> client.create_run(
+        >>>     project_id,
+        >>>     job_id,
+        >>>     [{"file": "data1.txt"}, {"file": "data2.txt"}]
+        >>> )
+
+        Many jobs do not take any arguments. In this case, simply pass a list
+        containing empty parameter value dictionaries, with the number of
+        entries in the list corresponding to the number of subruns you want:
+
+        >>> client.create_run(project_id, job_id, [{}, {}])
+
+        Parameters
+        ----------
+        project_id : uuid.UUID
+        job_id : uuid.UUID
+        parameter_value_sets : List[dict], optional
+            A list of parameter value sets. Each set of parameter values will
+            result in a subrun with those parameter values passed. Default:
+            single subrun with no parameter values.
+
+        Returns
+        -------
+        uuid.UUID
+            The ID of the created run.
+        """
+        print("starting...!!")
+
+        if parameter_value_sets is None:
+            parameter_value_sets = [{}]
+
+        endpoint = "/project/{}/job/{}/run".format(project_id, job_id)
+        payload = {
+            "parameterValues": [
+                [
+                    {"name": name, "value": value}
+                    for name, value in parameter_values.items()
+                ]
+                for parameter_values in parameter_value_sets
+            ]
+        }
+        print(payload)
+        response = self._post_raw(endpoint, json=payload)
+        print(response)
+        return uuid.UUID(response.json()["runId"])
+
+    def get_run_state(self, project_id, job_id, run_identifier):
+        """Get the state of a run.
+
+        Parameters
+        ----------
+        project_id : uuid.UUID
+        job_id : uuid.UUID
+        run_identifier : uuid.UUID or int
+            The ID of the run to get or its run number.
+
+        Returns
+        -------
+        RunState
+        """
+        endpoint = "/project/{}/job/{}/run/{}".format(
+            project_id, job_id, run_identifier
+        )
+        response = self._get_raw(endpoint)
+        state_raw = response.json()["state"]
+        return RunState(state_raw)

--- a/airflow_faculty_plugin/faculty/config.py
+++ b/airflow_faculty_plugin/faculty/config.py
@@ -1,0 +1,179 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import warnings
+from collections import namedtuple
+
+from six.moves.configparser import ConfigParser, NoSectionError, NoOptionError
+
+
+Profile = namedtuple(
+    "Profile", ["domain", "protocol", "client_id", "client_secret"]
+)
+
+DEFAULT_PROFILE = "default"
+DEFAULT_DOMAIN = "services.cloud.my.faculty.ai"
+DEFAULT_PROTOCOL = "https"
+
+
+def load(path):
+    """Read the Faculty configuration from a file."""
+
+    parser = ConfigParser()
+    parser.read(str(path))
+
+    def _get(section, option):
+        try:
+            return parser.get(section, option)
+        except (NoSectionError, NoOptionError):
+            return None
+
+    profiles = {}
+
+    for section in parser.sections():
+        profiles[section] = Profile(
+            domain=_get(section, "domain"),
+            protocol=_get(section, "protocol"),
+            client_id=_get(section, "client_id"),
+            client_secret=_get(section, "client_secret"),
+        )
+
+    return profiles
+
+
+def load_profile(path, profile):
+    """Read a Faculty profile from a file."""
+    profiles = load(path)
+    try:
+        return profiles[profile]
+    except KeyError:
+        return Profile(None, None, None, None)
+
+
+def _default_credentials_path():
+
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    if not xdg_config_home:
+        xdg_config_home = os.path.expanduser("~/.config")
+
+    default_path = os.path.join(xdg_config_home, "faculty", "credentials")
+    legacy_path = os.path.join(xdg_config_home, "sherlockml", "credentials")
+
+    if not os.path.exists(default_path) and os.path.exists(legacy_path):
+        template = (
+            "Reading credentials from {legacy_path}. Credentials at this path "
+            "are deprecated - please migrate by moving them to {default_path}."
+        )
+        warnings.warn(
+            template.format(legacy_path=legacy_path, default_path=default_path)
+        )
+        return legacy_path
+    else:
+        return default_path
+
+
+def _get_deprecated_env_var(key, expected_key):
+    value = os.getenv(key)
+
+    if value:
+        template = (
+            "The environment variable {key} is deprecated. "
+            "Please migrate by using {expected_key}."
+        )
+        warnings.warn(template.format(key=key, expected_key=expected_key))
+
+    return value
+
+
+def resolve_credentials_path(credentials_path=None):
+    return (
+        credentials_path
+        or os.getenv("FACULTY_CREDENTIALS_PATH")
+        or _get_deprecated_env_var(
+            "SHERLOCKML_CREDENTIALS_PATH", "FACULTY_CREDENTIALS_PATH"
+        )
+        or _default_credentials_path()
+    )
+
+
+class CredentialsError(RuntimeError):
+    pass
+
+
+def _raise_credentials_error(type_):
+    raise CredentialsError("No {} found".format(type_))
+
+
+def resolve_profile(
+    credentials_path=None,
+    profile_name=None,
+    domain=None,
+    protocol=None,
+    client_id=None,
+    client_secret=None,
+):
+
+    resolved_profile_name = (
+        profile_name
+        or os.getenv("FACULTY_PROFILE")
+        or _get_deprecated_env_var("SHERLOCKML_PROFILE", "FACULTY_PROFILE")
+        or DEFAULT_PROFILE
+    )
+
+    profile = load_profile(
+        resolve_credentials_path(credentials_path), resolved_profile_name
+    )
+
+    resolved_domain = (
+        domain
+        or os.getenv("FACULTY_DOMAIN")
+        or _get_deprecated_env_var("SHERLOCKML_DOMAIN", "FACULTY_DOMAIN")
+        or profile.domain
+        or DEFAULT_DOMAIN
+    )
+
+    resolved_protocol = (
+        protocol
+        or os.getenv("FACULTY_PROTOCOL")
+        or _get_deprecated_env_var("SHERLOCKML_PROTOCOL", "FACULTY_PROTOCOL")
+        or profile.protocol
+        or DEFAULT_PROTOCOL
+    )
+
+    resolved_client_id = (
+        client_id
+        or os.getenv("FACULTY_CLIENT_ID")
+        or _get_deprecated_env_var("SHERLOCKML_CLIENT_ID", "FACULTY_CLIENT_ID")
+        or profile.client_id
+        or _raise_credentials_error("client_id")
+    )
+
+    resolved_client_secret = (
+        client_secret
+        or os.getenv("FACULTY_CLIENT_SECRET")
+        or _get_deprecated_env_var(
+            "SHERLOCKML_CLIENT_SECRET", "FACULTY_CLIENT_SECRET"
+        )
+        or profile.client_secret
+        or _raise_credentials_error("client_secret")
+    )
+
+    return Profile(
+        domain=resolved_domain,
+        protocol=resolved_protocol,
+        client_id=resolved_client_id,
+        client_secret=resolved_client_secret,
+    )

--- a/airflow_faculty_plugin/faculty/session/__init__.py
+++ b/airflow_faculty_plugin/faculty/session/__init__.py
@@ -30,9 +30,7 @@ def _service_url(profile, service, endpoint=""):
 
 
 def _get_access_token(profile):
-    print("getting access token")
     url = _service_url(profile, "hudson", "access_token")
-    print(url)
     payload = {
         "client_id": profile.client_id,
         "client_secret": profile.client_secret,
@@ -40,7 +38,6 @@ def _get_access_token(profile):
     }
 
     response = requests.post(url, json=payload)
-    print(response)
     response.raise_for_status()
 
     body = response.json()

--- a/airflow_faculty_plugin/faculty/session/__init__.py
+++ b/airflow_faculty_plugin/faculty/session/__init__.py
@@ -1,0 +1,106 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from datetime import datetime, timedelta
+
+import pytz
+import requests
+from six.moves import urllib
+
+from .. import config as faculty_config
+from .accesstoken import AccessToken, AccessTokenMemoryCache
+
+
+def _service_url(profile, service, endpoint=""):
+    host = "{}.{}".format(service, profile.domain)
+    url_parts = (profile.protocol, host, endpoint, None, None)
+    return urllib.parse.urlunsplit(url_parts)
+
+
+def _get_access_token(profile):
+    print("getting access token")
+    url = _service_url(profile, "hudson", "access_token")
+    print(url)
+    payload = {
+        "client_id": profile.client_id,
+        "client_secret": profile.client_secret,
+        "grant_type": "client_credentials",
+    }
+
+    response = requests.post(url, json=payload)
+    print(response)
+    response.raise_for_status()
+
+    body = response.json()
+
+    token = body["access_token"]
+    now = datetime.now(tz=pytz.utc)
+    expires_at = now + timedelta(seconds=body["expires_in"])
+
+    return AccessToken(token, expires_at)
+
+
+class Session(object):
+    def __init__(self, profile, access_token_cache):
+        self.profile = profile
+        self.access_token_cache = access_token_cache
+
+    def access_token(self):
+        access_token = self.access_token_cache.get(self.profile)
+        if access_token is None:
+            access_token = _get_access_token(self.profile)
+            self.access_token_cache.add(self.profile, access_token)
+        return access_token
+
+    def service_url(self, service_name, endpoint=""):
+        return _service_url(self.profile, service_name, endpoint)
+
+
+_SESSION_CACHE = {}
+
+
+def get_session(
+    access_token_cache=None,
+    credentials_path=None,
+    profile_name=None,
+    domain=None,
+    protocol=None,
+    client_id=None,
+    client_secret=None,
+):
+    key = (
+        access_token_cache,
+        credentials_path,
+        profile_name,
+        domain,
+        protocol,
+        client_id,
+        client_secret,
+    )
+    try:
+        session = _SESSION_CACHE[key]
+    except KeyError:
+        profile = faculty_config.resolve_profile(
+            credentials_path=credentials_path,
+            profile_name=profile_name,
+            domain=domain,
+            protocol=protocol,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        access_token_cache = access_token_cache or AccessTokenMemoryCache()
+        session = Session(profile, access_token_cache)
+        _SESSION_CACHE[key] = session
+    return session

--- a/airflow_faculty_plugin/faculty/session/accesstoken.py
+++ b/airflow_faculty_plugin/faculty/session/accesstoken.py
@@ -53,7 +53,6 @@ def _is_valid_access_token(access_token_or_none):
         return access_token_or_none.expires_at >= datetime.now(tz=pytz.utc)
 
 
-
 class AccessTokenMemoryCache(object):
     def __init__(self):
         self._store = AccessTokenStore()

--- a/airflow_faculty_plugin/faculty/session/accesstoken.py
+++ b/airflow_faculty_plugin/faculty/session/accesstoken.py
@@ -1,0 +1,66 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import json
+import errno
+from datetime import datetime
+from collections import namedtuple
+
+import pytz
+
+
+AccessToken = namedtuple("AccessToken", ["token", "expires_at"])
+
+
+class AccessTokenStore(object):
+    def __init__(self, tokens=None):
+        self.tokens = tokens or {}
+
+    @staticmethod
+    def _hash_profile(profile):
+        return str(hash(profile))
+
+    def __getitem__(self, profile):
+        return self.tokens[self._hash_profile(profile)]
+
+    def __setitem__(self, profile, access_token):
+        self.tokens[self._hash_profile(profile)] = access_token
+
+    def get(self, profile):
+        try:
+            return self[profile]
+        except KeyError:
+            return None
+
+
+def _is_valid_access_token(access_token_or_none):
+    if access_token_or_none is None:
+        return False
+    else:
+        return access_token_or_none.expires_at >= datetime.now(tz=pytz.utc)
+
+
+
+class AccessTokenMemoryCache(object):
+    def __init__(self):
+        self._store = AccessTokenStore()
+
+    def get(self, profile):
+        access_token = self._store.get(profile)
+        return access_token if _is_valid_access_token(access_token) else None
+
+    def add(self, profile, access_token):
+        self._store[profile] = access_token

--- a/airflow_faculty_plugin/operators/__init__.py
+++ b/airflow_faculty_plugin/operators/__init__.py
@@ -1,2 +1,1 @@
-
 from .jobs import FacultyJobRunNowOperator  # noqa

--- a/airflow_faculty_plugin/operators/jobs.py
+++ b/airflow_faculty_plugin/operators/jobs.py
@@ -92,9 +92,7 @@ class FacultyJobRunNowOperator(BaseOperator):
             run_state = job_client.get_run_state(project_id, job_id, run_id)
             if run_state in COMPLETED_RUN_STATES:
                 if run_state == RunState.COMPLETED:
-                    log.info(
-                        f"Run {run_id} completed successfully."
-                    )
+                    log.info(f"Run {run_id} completed successfully.")
                     break
 
                 else:

--- a/airflow_faculty_plugin/operators/jobs.py
+++ b/airflow_faculty_plugin/operators/jobs.py
@@ -104,10 +104,8 @@ class FacultyJobRunNowOperator(BaseOperator):
                     )
             else:
                 log.info(
-                    f"Job {job_id} and run {run_id} in run state: {run_state}"
-                )
-                log.info(
-                    f"Sleeping for {self.polling_period_seconds} seconds."
+                    f"Run {run_id} in state: {run_state}. "
+                    f"Sleeping for {self.polling_period_seconds}."
                 )
                 time.sleep(self.polling_period_seconds)
 

--- a/airflow_faculty_plugin/operators/jobs.py
+++ b/airflow_faculty_plugin/operators/jobs.py
@@ -105,7 +105,7 @@ class FacultyJobRunNowOperator(BaseOperator):
             else:
                 log.info(
                     f"Run {run_id} in state: {run_state}. "
-                    f"Sleeping for {self.polling_period_seconds}."
+                    f"Sleeping for {self.polling_period_seconds}s."
                 )
                 time.sleep(self.polling_period_seconds)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages(),
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=["faculty"],
+    install_requires=["pytz", "requests"],
     entry_points={
         'airflow.plugins': [
             'unused = airflow_faculty_plugin:FacultyPlugin'


### PR DESCRIPTION
Airflow 10.6.x and later versions are incompatible with the Faculty library because they depend on marshmallow 2.x, whereas Faculty depends on Marshmallow 3.0.0.rc3 [1].

This PR mitigates this by vendoring a small subset of the Faculty library. Triggering jobs requires very little schema serialization and deserialization, and those bits are re-implemented without Marshamallow.

I've tested this against Medusa and it works as expected.

----

[1] Airflow 10.6 depends on flask-appbuilder < 2 ([ref](https://github.com/apache/airflow/blob/1.10.6/setup.py#L357)). flask-appbuilder < 2 depends on Marshmallow < 2.20 ([ref](https://github.com/dpgaspar/Flask-AppBuilder/blob/v1.13.1/setup.py#L49)).