### PR TITLE
Allow to select Job by name

### DIFF
--- a/airflow_faculty_plugin/faculty/clients/job.py
+++ b/airflow_faculty_plugin/faculty/clients/job.py
@@ -109,3 +109,25 @@ class JobClient(BaseClient):
         response = self._get_raw(endpoint)
         state_raw = response.json()["state"]
         return RunState(state_raw)
+
+    def list_names(self, project_id):
+        """List the job names in a project.
+
+        Parameters
+        ----------
+        project_id : uuid.UUID
+            The ID of the project to list jobs in.
+
+        Returns
+        -------
+        Dict[str, UUID]
+            Dictionary of job ID to job name.
+        """
+        endpoint = "/project/{}/job".format(project_id)
+        response = self._get_raw(endpoint).json()
+
+        job_names = {
+            summary["jobId"]: summary["meta"]["name"] for summary in response
+        }
+
+        return job_names

--- a/airflow_faculty_plugin/operators/jobs.py
+++ b/airflow_faculty_plugin/operators/jobs.py
@@ -4,6 +4,7 @@ import uuid
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
 
 from ..faculty import client
 from ..faculty.clients.job import RunState
@@ -32,7 +33,8 @@ class FacultyJobRunNowOperator(BaseOperator):
         quickly, and a high number if the job is longer. Defaults to
         30s.
     job_parameter_values : dict, optional
-        Dictionary mapping parameter names to the values they should take
+        Dictionary mapping parameter names to the values they should take.
+        (templated)
     task_id : str
         Identifier for the Airflow task triggered by this job
     client_configuration : dict, optional
@@ -44,9 +46,12 @@ class FacultyJobRunNowOperator(BaseOperator):
         Reference to the DAG that owns this task.
     """
 
+    template_fields = ["job_parameter_values"]
+
     ui_color = "#00aef9"
     ui_fgcolor = "#fff"
 
+    @apply_defaults
     def __init__(
         self,
         job_id_or_name,


### PR DESCRIPTION
Since Job names have been made unique, it is more user-friendly and
portable across project templates to select them by name as opposed to
ID.